### PR TITLE
home page route fixed

### DIFF
--- a/src/app/layouts/default/layout.tsx
+++ b/src/app/layouts/default/layout.tsx
@@ -17,7 +17,7 @@ function Layout(props) {
             <header className={layoutStyles.heroHead}>
                 <nav className={`${bulmaStyles.navbar} ${bulmaStyles.isTransparent}`} role="navigation" aria-label="main navigation">
                     <div className={bulmaStyles.navbarBrand}>
-                        <a className={bulmaStyles.navbarItem} href="https://acikkaynak.info/">
+                        <a className={bulmaStyles.navbarItem} href="/">
                             {`{ açık }`}
                         </a>
                         <span className={`${bulmaStyles.navbarBurger} ${bulmaStyles.burger}`} role="button" onClick={navbarToggle} aria-label="menu" aria-expanded="false" data-target="navbarMenu">


### PR DESCRIPTION
Home page anchor was directly linked into https://acikkaynak.info
Since website isn't active yet and using a forward slash more proper, I changed it instead.

Ana menü tuşu direkt olarak https://acikkaynak.info adresine yönlendiriyordu.
Henüz site aktif olmadığından ve eğik çizgi kullanmak daha uygun olacağından değiştirdim.