### PR TITLE
Fix broken links in guide

### DIFF
--- a/src/app/pages/learn/guide/view.tsx
+++ b/src/app/pages/learn/guide/view.tsx
@@ -16,7 +16,7 @@ function getPathDirname(pathString: string): string {
         return '';
     }
 
-    return pathString.substr(0, lastSlashIndex);
+    return `../${pathString.substr(0, lastSlashIndex)}`;
 }
 
 interface ViewProps {


### PR DESCRIPTION
<img width="560" alt="Screen Shot 2020-04-17 at 01 47 09" src="https://user-images.githubusercontent.com/11586390/79514381-be7eb200-804e-11ea-88b6-cf7a9c7462f9.png">

Fixes broken links as in the picture until there is a subfolder in the titles in the guide :)