### PR TITLE
Projeler sayfası için skeleton animasyonlu loader & css iyileştirmeleri

### DIFF
--- a/src/pages/projects/index.module.css
+++ b/src/pages/projects/index.module.css
@@ -4,7 +4,6 @@
   ul.projects {
     li {
       @apply rounded-md mb-8 shadow dark:shadow-black shadow-slate-400 focus:outline-none;
-
       /* unfortunately tailwind doesn't support dark:black in nested css */
       :global(.dark) & {
         @apply shadow-black
@@ -25,6 +24,19 @@
             @apply text-slate-200;
           }
         }
+      }
+    }
+  }
+  ul.projects-skeleton {
+    li {
+      @apply animate-pulse;
+    }
+    a {
+      div:nth-child(1) {
+        @apply w-48 h-7 rounded-sm bg-gray-200;
+      }
+      div:nth-child(2) {
+        @apply mt-2 w-full h-6 rounded-sm bg-gray-200;
       }
     }
   }

--- a/src/pages/projects/index.page.tsx
+++ b/src/pages/projects/index.page.tsx
@@ -11,7 +11,7 @@ const ProjectList = function ProjectList() {
   );
 
   if (isFetching) {
-    return <div>Yükleniyor...</div>;
+    return <ProjectsListSkeletonView />;
   }
 
   if (error) {
@@ -23,13 +23,28 @@ const ProjectList = function ProjectList() {
       {data?.items?.map((item) => (
         <li key={item.id}>
           <a href={item.html_url}>
-            <h4>
-              {item.full_name}
-            </h4>
+            <h4>{item.full_name}</h4>
             <div>{item.description}</div>
           </a>
         </li>
       ))}
+    </ul>
+  );
+};
+
+const ProjectsListSkeletonView = function ProjectsListSkeletonView() {
+  return (
+    <ul className={[styles.projects, styles["projects-skeleton"]].join(" ")}>
+      {Array(10)
+        .fill(null)
+        .map((_, index) => (
+          <li key={index}>
+            <a>
+              <div />
+              <div />
+            </a>
+          </li>
+        ))}
     </ul>
   );
 };

--- a/src/shared/layout/footer.module.css
+++ b/src/shared/layout/footer.module.css
@@ -1,5 +1,5 @@
 .footer {
-  @apply w-full container mx-auto flex flex-col gap-y-3 container mx-auto py-6 text-slate-600 mt-12;
+  @apply w-full container mx-auto flex flex-col gap-y-3 py-6 text-slate-600 mt-12;
 
   hr {
     @apply border border-slate-600;

--- a/src/shared/layout/index.module.css
+++ b/src/shared/layout/index.module.css
@@ -1,0 +1,6 @@
+.app {
+  @apply flex flex-col min-h-screen;
+  main {
+    @apply flex-1;
+  }
+}

--- a/src/shared/layout/index.tsx
+++ b/src/shared/layout/index.tsx
@@ -3,6 +3,7 @@ import Head from "next/head";
 import { Header } from "./header";
 import { Footer } from "./footer";
 import { type CustomAppProps } from "@webclient/pages/_app.types";
+import styles from "./index.module.css";
 
 interface LayoutProps {
   appProps: CustomAppProps;
@@ -15,16 +16,13 @@ const Layout = function Layout(props: LayoutProps) {
       <Head>
         <meta charSet="utf-8" />
         <link rel="icon" href="/favicon.ico" />
-        <meta
-          name="viewport"
-          content="width=device-width, initial-scale=1.0"
-        />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       </Head>
-      <Header />
-      <main>
-        {props.children}
-      </main>
-      <Footer />
+      <div className={styles.app}>
+        <Header />
+        <main>{props.children}</main>
+        <Footer />
+      </div>
     </>
   );
 };


### PR DESCRIPTION
- Projeler sayfasına skeleton view tarzı bir loading animasyonu eklendi.

https://user-images.githubusercontent.com/16894959/187658710-31359998-c7dd-4503-963a-29657983e3d8.mov

- Sayfada viewportu dolduracak kadar içerik bulunmadığı durumda footer'ın viewportun en alt kısmına sabitlenmesi

Öncesi:
<img width="1792" alt="Screen Shot 2022-08-31 at 1 32 13 PM" src="https://user-images.githubusercontent.com/16894959/187658947-8a3f3ca6-add2-4255-9dbf-480f8211779b.png">

Sonrası:
<img width="1792" alt="Screen Shot 2022-08-31 at 1 33 11 PM" src="https://user-images.githubusercontent.com/16894959/187659136-2abc416f-894d-4a29-9678-935c3c68ac8d.png">

Closes #116.